### PR TITLE
Changed broker volume path to /var/lib/kafka

### DIFF
--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 name: kafka
 description: Apache Kafka with Averbis Addons
-version: 0.0.4
+version: 0.0.5
 apiVersion: v1
 appVersion: "0.0.6"
 icon: https://upload.wikimedia.org/wikipedia/commons/0/05/Apache_kafka.svg

--- a/charts/kafka/templates/broker-deployment.yaml
+++ b/charts/kafka/templates/broker-deployment.yaml
@@ -32,7 +32,7 @@ spec:
             - containerPort: 9092
           resources: {}
           volumeMounts:
-            - mountPath: /var/lib/kafka/topic-data
+            - mountPath: /var/lib/kafka/
               name: brokervol
       hostname: broker
       restartPolicy: Always


### PR DESCRIPTION
Change the broker volume path to` /var/lib/kafka` instead of `/var/lib/kafka/topic-data` to work around issues with `lost+found` folder in kafka topic directory.