### PR TITLE
Removed `enabled: true` property from securityContext.

### DIFF
--- a/charts/health-discovery/Chart.yaml
+++ b/charts/health-discovery/Chart.yaml
@@ -1,6 +1,6 @@
 name: health-discovery
 description: Health Discovery is the healthcare text mining and machine learning platform for analyzing large amounts of patient data
-version: 7.0.1
+version: 7.0.2
 apiVersion: v1
 keywords:
   - health-discovery

--- a/charts/health-discovery/templates/database-deployment.yaml
+++ b/charts/health-discovery/templates/database-deployment.yaml
@@ -26,7 +26,6 @@ spec:
         io.kompose.service: database
     spec:
       securityContext:
-        enabled: true
         runAsUser: 999
         fsGroup: 999
       containers:

--- a/charts/health-discovery/templates/health-discovery-deployment.yaml
+++ b/charts/health-discovery/templates/health-discovery-deployment.yaml
@@ -25,7 +25,6 @@ spec:
         io.kompose.service: health-discovery
     spec:
       securityContext:
-            enabled: true
             runAsUser: 1000
             fsGroup: 1000
       imagePullSecrets:

--- a/charts/health-discovery/templates/solr-deployment.yaml
+++ b/charts/health-discovery/templates/solr-deployment.yaml
@@ -25,7 +25,6 @@ spec:
         io.kompose.service: solr
     spec:
       securityContext:
-          enabled: true
           runAsUser: 1000
           fsGroup: 1000
       imagePullSecrets:


### PR DESCRIPTION
Removed `enabled: true` property from securityContext. It is no longer needed and is causing a warning when the helm chart is installed.