### PR TITLE
Possibility to define node specification #64

### DIFF
--- a/charts/health-discovery/README.md
+++ b/charts/health-discovery/README.md
@@ -56,6 +56,15 @@ The chart can optionally be configured using the following parameters:
 | `existingDbSecret`  | Use MariaDB credentials from an existing secret. The secret has to contain the keys `databaseUsername` and `databasePassword`. Please refer to the [kubernetes documentation](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/) for more information about how to create secrets | "" |
 | `externalDbConnectionUrl` | JDBC connection URL of an external MariaDB 10.x database. Requires the `existingDbSecret` parameter to be set | "" |
 | `registryUrl` | Container registry URL      | registry.averbis.com               |
+| `database.tolerations` | Node Tolerations | [] |
+| `database.affinity` | Node Affinity | {} |
+| `database.nodeSelector` | Node Selector | {} |
+| `healthDiscovery.tolerations` | Node Tolerations | [] |
+| `healthDiscovery.affinity` | Node Affinity | {} |
+| `healthDiscovery.nodeSelector` | Node Selector | {} |
+| `solr.tolerations` | Node Tolerations | [] |
+| `solr.affinity` | Node Affinity | {} |
+| `solr.nodeSelector` | Node Selector | {} |
 
 
 Specify each parameter using the `--set name=value` argument to `helm install` and `helm upgrade`  to overwrite the chart default values, for example:

--- a/charts/health-discovery/templates/database-deployment.yaml
+++ b/charts/health-discovery/templates/database-deployment.yaml
@@ -80,5 +80,17 @@ spec:
         - name: dbvol
           persistentVolumeClaim:
             claimName: dbvol
+      {{- with (.Values.database).tolerations }}
+      tolerations:
+      {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.database).affinity }}
+      affinity:
+      {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.database).nodeSelector }}
+      nodeSelector:
+      {{ toYaml . | nindent 8 }}
+      {{- end }}
 status: {}
 {{ end }}

--- a/charts/health-discovery/templates/health-discovery-deployment.yaml
+++ b/charts/health-discovery/templates/health-discovery-deployment.yaml
@@ -97,4 +97,16 @@ spec:
         - name: resourcevol
           persistentVolumeClaim:
             claimName: resourcevol
+      {{- with (.Values.healthDiscovery).tolerations }}
+      tolerations:
+      {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.healthDiscovery).affinity }}
+      affinity:
+      {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.healthDiscovery).nodeSelector }}
+      nodeSelector:
+      {{ toYaml . | nindent 8 }}
+      {{- end }}
 status: {}

--- a/charts/health-discovery/templates/solr-deployment.yaml
+++ b/charts/health-discovery/templates/solr-deployment.yaml
@@ -62,4 +62,16 @@ spec:
         - name: solrvol
           persistentVolumeClaim:
             claimName: solrvol
+      {{- with (.Values.solr).tolerations }}
+      tolerations:
+      {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.solr).affinity }}
+      affinity:
+      {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.solr).nodeSelector }}
+      nodeSelector:
+      {{ toYaml . | nindent 8 }}
+      {{- end }}
 status: {}


### PR DESCRIPTION
Since the application requires a dedicated machine with increased RAM and CPU resources, we find it useful to define tolerations, node affinity, and node selectors. This ensures that other workloads are not scheduled on dedicated nodes while allowing end users to specify the appropriate nodes for running the Averbis workload.

Implements issue #64 